### PR TITLE
fix: use with_block_info query parameter to get block height and proposer

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -64,6 +64,7 @@ interface DatapointRequest {
   from?: number;
   to?: number;
   limit?: number;
+  withBlockInfo?: boolean;
 }
 
 export async function getRawMEV(params: DatapointRequest) {
@@ -82,6 +83,10 @@ export async function getRawMEV(params: DatapointRequest) {
 
   if (params.limit) {
     query.append("limit", params.limit.toString());
+  }
+
+  if (params.withBlockInfo) {
+    query.append("with_block_info", params.withBlockInfo.toString());
   }
 
   const response = await axios.get(`${API_URL}/v1/raw_mev?${query.toString()}`);
@@ -127,7 +132,7 @@ export function useValidatorsQuery() {
   });
 }
 
-export function useRawMEVQuery(proposer: string, blocks: number) {
+export function useRawMEVQuery(proposer: string, blocks: number, withBlockInfo: boolean) {
   return useQuery({
     queryKey: ["raw-mev", proposer, blocks],
     queryFn: async () => {
@@ -143,6 +148,7 @@ export function useRawMEVQuery(proposer: string, blocks: number) {
         from: fromHeight,
         to: toHeight,
         limit: 1000,
+        withBlockInfo: withBlockInfo,
       });
     },
     enabled: proposer !== "",

--- a/src/pages/validators/[pubkey].tsx
+++ b/src/pages/validators/[pubkey].tsx
@@ -38,7 +38,7 @@ function ValidatorPage() {
     return validators.find((validator) => validator.pubkey === pubkey);
   }, [validators, pubkey]);
 
-  const { data: datapoints } = useRawMEVQuery(validator?.pubkey || "", 43200);
+  const { data: datapoints } = useRawMEVQuery(validator?.pubkey || "", 43200, true);
 
   const formattedDatapoints = useMemo(() => {
     if (!datapoints) {


### PR DESCRIPTION
Following the PR in the API service, this PR uses the `with_block_info` parameter to fix the tooltip issue.