### PR TITLE
feat(api): aggregates validator stats calls instead of making many

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,8 +1,7 @@
 import axios from "axios";
 import { useQuery } from "@tanstack/react-query";
 
-const API_URL = "https://zygis-dydx.ngrok.app";
-// const API_URL = "https://dydx-mev-api-dev.skip.money";
+const API_URL = "https://dydx-mev-api-dev.skip.money";
 // const API_URL = "https://dydx-mev-api-prod.skip.money";
 
 export interface Validator {


### PR DESCRIPTION
## In this PR

As we talked previously, this makes a single call to validator stats (which will return an array of {averageMev, validatorPubkey}) instead of multiple calls indexed by validatorPubkey
