### PR TITLE
[SPE-2] feat: update chart validator highlighter sorting

### DIFF
--- a/src/components/pages/home/MainChartToggles.tsx
+++ b/src/components/pages/home/MainChartToggles.tsx
@@ -5,6 +5,7 @@ import {
   resetSelectedValidators,
   useHomeStore,
 } from "@/store/home";
+import { ValidatorComparer } from "@/types/utils";
 import { ComponentProps, useEffect } from "react";
 
 export const MainChartToggles = (props: ComponentProps<"div">) => {
@@ -18,7 +19,7 @@ export const MainChartToggles = (props: ComponentProps<"div">) => {
       if (hideInactive) {
         arr = arr.filter((validator) => validator.stake !== "0");
       }
-      return arr;
+      return arr.sort(ValidatorComparer.AVERAGE_MEV_DESC);
     },
   });
 

--- a/src/hooks/validator.ts
+++ b/src/hooks/validator.ts
@@ -1,5 +1,6 @@
 import { getValidatorStats, getValidators } from "@/api";
 import { Validator, ValidatorWithStats } from "@/types/base";
+import { ValidatorComparer } from "@/types/utils";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useLatestHeightQuery } from "./height";
@@ -57,9 +58,7 @@ export function useValidatorsWithStatsQuery<T = ValidatorWithStats[]>(
         };
       }
 
-      const validatorWithStats = args.validators
-        .map(withStats)
-        .sort((a, b) => b.averageMev - a.averageMev);
+      const validatorWithStats = args.validators.map(withStats);
 
       return validatorWithStats;
     },

--- a/src/store/home.ts
+++ b/src/store/home.ts
@@ -20,7 +20,7 @@ export const useHomeStore = /* @__PURE__ */ create(
   subscribeWithSelector<HomeStore>(() => ({
     searchValue: "",
     blocks: 43200,
-    sortBy: "stake",
+    sortBy: "averageMev",
     sortDirection: "desc",
     selectedValidators: [],
     selectedValidatorsSet: new Set(),


### PR DESCRIPTION
## Description

This PR improves the default sorting method for charts and other queries. Dependent on #25.

## Changes

- [update loading state queries](https://github.com/skip-mev/dydx-dashboard/pull/24/commits/218b897c942e5018aac29d613e85a0458086a2eb)

## Links

https://linear.app/skip/issue/SPE-2/use-cumulative-mev-to-sort-the-validators-below-the-chart-the
