### PR TITLE
feat: use SENTRY_DSN env variable

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -4,8 +4,12 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
 Sentry.init({
-  dsn: "https://8c14a825146b8bd474baf194a5d7fc50@o4504768725909504.ingest.sentry.io/4505624305139712",
+  dsn:
+    SENTRY_DSN ||
+    "https://8c14a825146b8bd474baf194a5d7fc50@o4504768725909504.ingest.sentry.io/4505624305139712",
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,8 +5,12 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
 Sentry.init({
-  dsn: "https://8c14a825146b8bd474baf194a5d7fc50@o4504768725909504.ingest.sentry.io/4505624305139712",
+  dsn:
+    SENTRY_DSN ||
+    "https://8c14a825146b8bd474baf194a5d7fc50@o4504768725909504.ingest.sentry.io/4505624305139712",
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,8 +4,12 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+
 Sentry.init({
-  dsn: "https://8c14a825146b8bd474baf194a5d7fc50@o4504768725909504.ingest.sentry.io/4505624305139712",
+  dsn:
+    SENTRY_DSN ||
+    "https://8c14a825146b8bd474baf194a5d7fc50@o4504768725909504.ingest.sentry.io/4505624305139712",
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,


### PR DESCRIPTION
## Description

This PR ensures Sentry uses the SENTRY_DSN env var first then fallbacks to the hardcoded DSN value.
