### PR TITLE
[FRE-407] fix: change validator table cell link overflow behavior

### DIFF
--- a/src/components/pages/home/ValidatorsTable.tsx
+++ b/src/components/pages/home/ValidatorsTable.tsx
@@ -91,7 +91,6 @@ export const ValidatorsTable = () => {
                 <TableRow
                   key={validator.pubkey}
                   className={clsx({
-                    relative: true,
                     "md:[&>:first-child]:rounded-bl-lg": isLast,
                     "md:[&>:last-child]:rounded-br-lg": isLast,
                   })}
@@ -99,8 +98,8 @@ export const ValidatorsTable = () => {
                   <TableCell className="max-w-[50vw] w-2/4">
                     <Link
                       className={clsx(
-                        "text-[#6398FF] flex items-center gap-1 hover:underline overflow-hidden",
-                        "after:content-[''] after:absolute after:inset-0"
+                        "text-[#6398FF] flex items-center gap-1 hover:underline relative",
+                        "after:content-[''] after:absolute after:-inset-4"
                       )}
                       href={`/validators/${validator.pubkey}`}
                     >


### PR DESCRIPTION
## Description

This PR changes the validator table cell link overflow behavior.

Previously users can click the whole row, but apparently mf safari decides to ignore the relative positioning of the row and overflows everywhere. With this change, only the cell with the link itself is clickable.